### PR TITLE
Add documentation for terminal loading component

### DIFF
--- a/packages/@react-spectrum/button/docs/Button.mdx
+++ b/packages/@react-spectrum/button/docs/Button.mdx
@@ -86,7 +86,11 @@ function Example() {
 
 ## Pending
 
-Buttons can indicate that a quick progress task is taking place (e.g., saving settings on a server). After a 1 second delay, an indeterminate spinner will be displayed in place of the button label and icon. You can trigger this behavior with the `isPending` prop. Button events are disabled while `isPending` is true.
+Buttons can indicate that a quick progress task is taking place (e.g., saving settings on a server). After a 1 second delay, a loading indicator will be displayed in place of the button label and icon. You can trigger this behavior with the `isPending` prop. Button events are disabled while `isPending` is true.
+
+### Spinner Loading (Default)
+
+By default, buttons show an indeterminate spinner during loading states:
 
 ```tsx example
 function Example() {
@@ -107,6 +111,87 @@ function Example() {
   );
 }
 ```
+
+### Terminal Loading
+
+For a nostalgic terminal-style loading animation, use the `loadingStyle="terminal"` prop. This displays cycling dots after the loading text (e.g., 'Loading', 'Loading.', 'Loading..', 'Loading...'):
+
+```tsx example
+function Example() {
+  let [isLoading, setIsLoading] = React.useState(false);
+
+  let handlePress = () => {
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 3000);
+  };
+
+  return (
+    <Button 
+      variant="primary" 
+      isPending={isLoading} 
+      loadingStyle="terminal"
+      onPress={handlePress}
+    >
+      Save File
+    </Button>
+  );
+}
+```
+
+### Customizing Terminal Loading
+
+The terminal loading animation can be customized with additional props:
+
+```tsx example
+function Example() {
+  let [isLoading, setIsLoading] = React.useState(false);
+
+  let handlePress = () => {
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 4000);
+  };
+
+  return (
+    <Flex direction="column" gap="size-150">
+      <Button 
+        variant="primary" 
+        isPending={isLoading} 
+        loadingStyle="terminal"
+        loadingText="Processing"
+        loadingSpeed={300}
+        loadingDots={3}
+        onPress={handlePress}
+      >
+        Custom Terminal
+      </Button>
+      <Button 
+        variant="accent" 
+        isPending={isLoading} 
+        loadingStyle="terminal"
+        loadingText="Uploading"
+        loadingSpeed={600}
+        onPress={handlePress}
+      >
+        Slow Animation
+      </Button>
+    </Flex>
+  );
+}
+```
+
+#### Terminal Loading Props
+
+- **`loadingText`**: Custom text to display (default: 'Loading')
+- **`loadingSpeed`**: Animation speed in milliseconds per frame (default: 500ms)
+- **`loadingDots`**: Maximum number of dots to cycle through (default: 4)
+
+### Accessibility
+
+Terminal loading maintains the same accessibility features as spinner loading:
+- Screen reader announcements when loading state changes
+- Proper ARIA labels and live regions for dynamic text updates
+- Focus management during loading states
+- Button remains focusable but interaction is disabled
 
 ## Props
 


### PR DESCRIPTION
Closes 

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

1.  Build the documentation locally.
2.  Navigate to the Button component documentation (`packages/@react-spectrum/button/docs/Button.mdx`).
3.  Verify the new "Terminal Loading" section is present under "Pending".
4.  Confirm the basic usage example, customization examples, and the "Terminal Loading Props" table are displayed correctly.
5.  Check that the "Accessibility" subsection for terminal loading is included.

## 🧢 Your Project:

---
<a href="https://cursor.com/background-agent?bcId=bc-063fd666-cc33-4773-9400-9a4012e5c246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-063fd666-cc33-4773-9400-9a4012e5c246">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

