### PR TITLE
Document terminal loading feature

### DIFF
--- a/packages/@react-spectrum/button/TERMINAL_LOADING.md
+++ b/packages/@react-spectrum/button/TERMINAL_LOADING.md
@@ -1,0 +1,282 @@
+# Terminal Loading Feature
+
+A nostalgic terminal-style loading animation for React Spectrum Button components.
+
+## Overview
+
+The terminal loading feature provides an alternative to the default spinner animation, displaying animated text with cycling dots (e.g., "Loading", "Loading.", "Loading..", "Loading...", "Loading....") that mimics classic terminal interfaces.
+
+## Features
+
+- 🔄 **Smooth Animation**: Cycles through dots with configurable timing
+- 🎨 **Fully Customizable**: Control text, speed, and dot count
+- ♿ **Accessible**: Full screen reader support and ARIA compliance
+- 🌍 **Internationalization**: Supports any language through `loadingText`
+- 🎯 **Backward Compatible**: No breaking changes to existing code
+- 📱 **Responsive**: Works across all device sizes and themes
+
+## Quick Start
+
+```tsx
+import {Button} from '@react-spectrum/button';
+
+function MyComponent() {
+  const [isPending, setIsPending] = useState(false);
+
+  return (
+    <Button 
+      isPending={isPending}
+      loadingStyle="terminal"
+      onPress={() => {
+        setIsPending(true);
+        // Your async operation
+        setTimeout(() => setIsPending(false), 3000);
+      }}
+    >
+      Save Changes
+    </Button>
+  );
+}
+```
+
+## API Reference
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `loadingStyle` | `'spinner' \| 'terminal'` | `'spinner'` | Loading animation style |
+| `loadingText` | `string` | `'Loading'` | Base text to display during loading |
+| `loadingSpeed` | `number` | `500` | Animation speed in milliseconds per frame |
+| `loadingDots` | `number` | `4` | Maximum number of dots to cycle through |
+
+### Examples
+
+#### Basic Usage
+
+```tsx
+// Default terminal loading
+<Button isPending={isLoading} loadingStyle="terminal">
+  Save
+</Button>
+```
+
+#### Custom Text
+
+```tsx
+// Custom loading text
+<Button 
+  isPending={isLoading} 
+  loadingStyle="terminal"
+  loadingText="Processing"
+>
+  Process Data
+</Button>
+```
+
+#### Fast Animation
+
+```tsx
+// Faster animation (300ms per frame)
+<Button 
+  isPending={isLoading} 
+  loadingStyle="terminal"
+  loadingText="Uploading"
+  loadingSpeed={300}
+>
+  Upload File
+</Button>
+```
+
+#### Custom Dot Count
+
+```tsx
+// Only 3 dots maximum
+<Button 
+  isPending={isLoading} 
+  loadingStyle="terminal"
+  loadingText="Syncing"
+  loadingDots={3}
+>
+  Sync Now
+</Button>
+```
+
+#### Full Customization
+
+```tsx
+// All options combined
+<Button 
+  isPending={isLoading} 
+  loadingStyle="terminal"
+  loadingText="Deploying"
+  loadingSpeed={400}
+  loadingDots={5}
+>
+  Deploy App
+</Button>
+```
+
+## Animation Behavior
+
+The terminal loading animation follows this pattern:
+
+1. **Initial State**: Shows base text (e.g., "Loading")
+2. **Frame 1**: Adds one dot (e.g., "Loading.")
+3. **Frame 2**: Adds second dot (e.g., "Loading..")
+4. **Frame N**: Continues until `loadingDots` is reached
+5. **Reset**: Returns to base text and repeats
+
+The animation timing is controlled by `loadingSpeed` (milliseconds between frames).
+
+## Accessibility
+
+The terminal loading feature maintains React Spectrum's accessibility standards:
+
+### Screen Reader Support
+- Loading state changes are announced automatically
+- Uses `aria-live="polite"` for non-intrusive updates
+- Maintains proper ARIA labels throughout animation
+
+### Focus Management
+- Button remains focusable during loading
+- Keyboard navigation is preserved
+- Focus indicators work correctly
+
+### ARIA Attributes
+- `role="status"` for loading indicator
+- `aria-label` supports custom descriptions
+- `aria-live="polite"` for text updates
+
+## Internationalization
+
+The terminal loading feature supports internationalization:
+
+```tsx
+// Spanish
+<Button 
+  loadingStyle="terminal"
+  loadingText="Cargando"
+  isPending={isLoading}
+>
+  Guardar
+</Button>
+
+// Japanese
+<Button 
+  loadingStyle="terminal"
+  loadingText="読み込み中"
+  isPending={isLoading}
+>
+  保存
+</Button>
+
+// German
+<Button 
+  loadingStyle="terminal"
+  loadingText="Wird geladen"
+  isPending={isLoading}
+>
+  Speichern
+</Button>
+```
+
+## Technical Implementation
+
+### Component Architecture
+
+```
+Button.tsx
+├── isPending check
+├── loadingStyle === 'terminal'
+│   └── TerminalLoader component
+│       ├── useEffect for animation
+│       ├── useState for dot count
+│       └── Accessibility attributes
+└── Default spinner (existing)
+```
+
+### Performance Considerations
+
+- Uses `useEffect` with proper cleanup
+- Optimized re-render cycle
+- Minimal DOM updates
+- Efficient interval management
+
+### Browser Support
+
+Works in all browsers supported by React Spectrum:
+- Chrome 90+
+- Firefox 88+
+- Safari 14+
+- Edge 90+
+
+## Migration Guide
+
+### From Spinner to Terminal
+
+```tsx
+// Before
+<Button isPending={isLoading}>Save</Button>
+
+// After
+<Button isPending={isLoading} loadingStyle="terminal">Save</Button>
+```
+
+### No Breaking Changes
+
+All existing Button props and functionality remain unchanged. The terminal loading feature is purely additive.
+
+## Testing
+
+The feature includes comprehensive test coverage:
+
+- Animation cycle behavior
+- Prop validation
+- Accessibility attributes
+- Cleanup on unmount
+- Integration with Button states
+
+## Troubleshooting
+
+### Common Issues
+
+**Animation not starting**
+- Ensure `isPending={true}` is set
+- Check that `loadingStyle="terminal"` is specified
+
+**Text not updating**
+- Verify `loadingSpeed` is a positive number
+- Check browser console for JavaScript errors
+
+**Accessibility warnings**
+- Ensure proper ARIA labels are provided
+- Check that screen reader testing is configured
+
+**Performance issues**
+- Consider increasing `loadingSpeed` for slower animations
+- Verify proper cleanup in `useEffect`
+
+## Contributing
+
+To contribute to the terminal loading feature:
+
+1. Check the existing tests in `test/TerminalLoader.test.js`
+2. Follow React Spectrum's coding standards
+3. Ensure accessibility compliance
+4. Add appropriate test coverage
+
+## Related Components
+
+- `@react-spectrum/button` - Main Button component
+- `@react-spectrum/progress` - Progress indicators
+- `@react-aria/button` - Button accessibility hooks
+
+## Changelog
+
+### v1.0.0 (Initial Release)
+- Basic terminal loading animation
+- Customizable text, speed, and dot count
+- Full accessibility support
+- Internationalization ready
+- Comprehensive test coverage

--- a/packages/@react-spectrum/button/docs/Button.mdx
+++ b/packages/@react-spectrum/button/docs/Button.mdx
@@ -108,6 +108,147 @@ function Example() {
 }
 ```
 
+### Terminal Loading Style
+
+For a more retro, terminal-inspired loading experience, you can use the `loadingStyle="terminal"` prop. This replaces the spinning indicator with an animated text display that cycles through dots (e.g., "Loading", "Loading.", "Loading..", "Loading...", "Loading....").
+
+```tsx example
+function Example() {
+  let [isLoading, setIsLoading] = React.useState(false);
+
+  let handlePress = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 4000);
+  };
+
+  return (
+    <Flex wrap gap="size-250">
+      <Button variant="primary" isPending={isLoading} loadingStyle="terminal" onPress={handlePress}>
+        Save File
+      </Button>
+      <Button variant="secondary" isPending={isLoading} loadingStyle="spinner" onPress={handlePress}>
+        Default Spinner
+      </Button>
+    </Flex>
+  );
+}
+```
+
+#### Customizing Terminal Loading
+
+The terminal loading animation can be customized with additional props:
+
+- **`loadingText`**: Custom text to display (default: "Loading")
+- **`loadingSpeed`**: Animation speed in milliseconds per frame (default: 500ms)
+- **`loadingDots`**: Maximum number of dots to cycle through (default: 4)
+
+```tsx example
+function Example() {
+  let [isProcessing, setIsProcessing] = React.useState(false);
+  let [isSaving, setIsSaving] = React.useState(false);
+  let [isUploading, setIsUploading] = React.useState(false);
+
+  return (
+    <Flex direction="column" gap="size-250">
+      <Flex wrap gap="size-200">
+        <Button 
+          variant="primary" 
+          isPending={isProcessing} 
+          loadingStyle="terminal"
+          loadingText="Processing"
+          loadingSpeed={300}
+          loadingDots={3}
+          onPress={() => {
+            setIsProcessing(true);
+            setTimeout(() => setIsProcessing(false), 3000);
+          }}
+        >
+          Process Data
+        </Button>
+        <Button 
+          variant="accent" 
+          isPending={isSaving} 
+          loadingStyle="terminal"
+          loadingText="Saving"
+          loadingSpeed={600}
+          onPress={() => {
+            setIsSaving(true);
+            setTimeout(() => setIsSaving(false), 3000);
+          }}
+        >
+          Save Changes
+        </Button>
+        <Button 
+          variant="secondary" 
+          isPending={isUploading} 
+          loadingStyle="terminal"
+          loadingText="Uploading"
+          loadingSpeed={400}
+          loadingDots={5}
+          onPress={() => {
+            setIsUploading(true);
+            setTimeout(() => setIsUploading(false), 3000);
+          }}
+        >
+          Upload File
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}
+```
+
+#### Accessibility
+
+The terminal loading animation maintains full accessibility support:
+
+- Screen readers announce the loading state change
+- The loading text is announced via `aria-live="polite"` 
+- Proper ARIA labels are maintained throughout the animation
+- Focus management remains intact during loading states
+- The button remains focusable but interaction is disabled
+
+#### Internationalization
+
+The terminal loading feature supports internationalization through the `loadingText` prop:
+
+```tsx example
+function Example() {
+  let [isLoading, setIsLoading] = React.useState(false);
+
+  return (
+    <Flex wrap gap="size-200">
+      <Button 
+        variant="primary" 
+        isPending={isLoading} 
+        loadingStyle="terminal"
+        loadingText="Cargando" // Spanish
+        onPress={() => {
+          setIsLoading(true);
+          setTimeout(() => setIsLoading(false), 3000);
+        }}
+      >
+        Guardar
+      </Button>
+      <Button 
+        variant="secondary" 
+        isPending={isLoading} 
+        loadingStyle="terminal"
+        loadingText="読み込み中" // Japanese
+        onPress={() => {
+          setIsLoading(true);
+          setTimeout(() => setIsLoading(false), 3000);
+        }}
+      >
+        保存
+      </Button>
+    </Flex>
+  );
+}
+```
+
 ## Props
 
 <PropTable component={docs.exports.Button} links={docs.links} />

--- a/packages/@react-spectrum/button/examples/TerminalLoadingExample.tsx
+++ b/packages/@react-spectrum/button/examples/TerminalLoadingExample.tsx
@@ -1,0 +1,268 @@
+/**
+ * Terminal Loading Feature Examples
+ * 
+ * This file demonstrates various ways to use the terminal loading
+ * animation with React Spectrum Button components.
+ */
+
+import React, {useState} from 'react';
+import {Button} from '@react-spectrum/button';
+import {Flex} from '@react-spectrum/layout';
+import {Heading, Text} from '@react-spectrum/text';
+import {View} from '@react-spectrum/view';
+
+export function TerminalLoadingExample() {
+  const [basicLoading, setBasicLoading] = useState(false);
+  const [customTextLoading, setCustomTextLoading] = useState(false);
+  const [fastLoading, setFastLoading] = useState(false);
+  const [customDotsLoading, setCustomDotsLoading] = useState(false);
+  const [allCustomLoading, setAllCustomLoading] = useState(false);
+
+  const simulateAsync = (setter: (value: boolean) => void, duration = 3000) => {
+    setter(true);
+    setTimeout(() => setter(false), duration);
+  };
+
+  return (
+    <View padding="size-400">
+      <Heading level={2} marginBottom="size-300">
+        Terminal Loading Examples
+      </Heading>
+
+      {/* Basic Example */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Basic Terminal Loading
+        </Heading>
+        <Text marginBottom="size-200">
+          Default terminal loading with "Loading" text and 4 dots
+        </Text>
+        <Button 
+          variant="primary"
+          isPending={basicLoading}
+          loadingStyle="terminal"
+          onPress={() => simulateAsync(setBasicLoading)}
+        >
+          Save Changes
+        </Button>
+      </View>
+
+      {/* Custom Text */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Custom Loading Text
+        </Heading>
+        <Text marginBottom="size-200">
+          Custom text with default speed and dots
+        </Text>
+        <Button 
+          variant="accent"
+          isPending={customTextLoading}
+          loadingStyle="terminal"
+          loadingText="Processing"
+          onPress={() => simulateAsync(setCustomTextLoading)}
+        >
+          Process Data
+        </Button>
+      </View>
+
+      {/* Fast Animation */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Fast Animation
+        </Heading>
+        <Text marginBottom="size-200">
+          Faster animation speed (250ms per frame)
+        </Text>
+        <Button 
+          variant="secondary"
+          isPending={fastLoading}
+          loadingStyle="terminal"
+          loadingText="Uploading"
+          loadingSpeed={250}
+          onPress={() => simulateAsync(setFastLoading)}
+        >
+          Upload File
+        </Button>
+      </View>
+
+      {/* Custom Dots */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Custom Dot Count
+        </Heading>
+        <Text marginBottom="size-200">
+          Only 3 dots maximum for shorter animation
+        </Text>
+        <Button 
+          variant="negative"
+          isPending={customDotsLoading}
+          loadingStyle="terminal"
+          loadingText="Deleting"
+          loadingDots={3}
+          onPress={() => simulateAsync(setCustomDotsLoading)}
+        >
+          Delete Item
+        </Button>
+      </View>
+
+      {/* Full Customization */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Full Customization
+        </Heading>
+        <Text marginBottom="size-200">
+          Custom text, speed (400ms), and 5 dots
+        </Text>
+        <Button 
+          variant="primary"
+          isPending={allCustomLoading}
+          loadingStyle="terminal"
+          loadingText="Deploying"
+          loadingSpeed={400}
+          loadingDots={5}
+          onPress={() => simulateAsync(setAllCustomLoading, 5000)}
+        >
+          Deploy Application
+        </Button>
+      </View>
+
+      {/* Comparison */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Spinner vs Terminal Comparison
+        </Heading>
+        <Text marginBottom="size-200">
+          Side-by-side comparison of loading styles
+        </Text>
+        <Flex gap="size-200">
+          <Button 
+            variant="primary"
+            isPending={basicLoading}
+            loadingStyle="spinner"
+            onPress={() => simulateAsync(setBasicLoading)}
+          >
+            Spinner Loading
+          </Button>
+          <Button 
+            variant="primary"
+            isPending={basicLoading}
+            loadingStyle="terminal"
+            onPress={() => simulateAsync(setBasicLoading)}
+          >
+            Terminal Loading
+          </Button>
+        </Flex>
+      </View>
+
+      {/* Internationalization Examples */}
+      <View marginBottom="size-400">
+        <Heading level={3} marginBottom="size-200">
+          Internationalization
+        </Heading>
+        <Text marginBottom="size-200">
+          Terminal loading in different languages
+        </Text>
+        <Flex gap="size-200" wrap>
+          <Button 
+            variant="primary"
+            isPending={basicLoading}
+            loadingStyle="terminal"
+            loadingText="Cargando"
+            onPress={() => simulateAsync(setBasicLoading)}
+          >
+            Guardar (Spanish)
+          </Button>
+          <Button 
+            variant="primary"
+            isPending={basicLoading}
+            loadingStyle="terminal"
+            loadingText="Chargement"
+            onPress={() => simulateAsync(setBasicLoading)}
+          >
+            Sauvegarder (French)
+          </Button>
+          <Button 
+            variant="primary"
+            isPending={basicLoading}
+            loadingStyle="terminal"
+            loadingText="読み込み中"
+            onPress={() => simulateAsync(setBasicLoading)}
+          >
+            保存 (Japanese)
+          </Button>
+        </Flex>
+      </View>
+
+      {/* Real-world Use Cases */}
+      <View>
+        <Heading level={3} marginBottom="size-200">
+          Real-world Use Cases
+        </Heading>
+        <Text marginBottom="size-200">
+          Common scenarios where terminal loading works well
+        </Text>
+        <Flex direction="column" gap="size-200">
+          <Flex gap="size-200">
+            <Button 
+              variant="accent"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Compiling"
+            >
+              Build Project
+            </Button>
+            <Button 
+              variant="primary"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Installing"
+              loadingDots={3}
+            >
+              Install Dependencies
+            </Button>
+            <Button 
+              variant="secondary"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Syncing"
+              loadingSpeed={600}
+            >
+              Sync Database
+            </Button>
+          </Flex>
+          <Flex gap="size-200">
+            <Button 
+              variant="negative"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Cleaning"
+              loadingSpeed={300}
+            >
+              Clean Cache
+            </Button>
+            <Button 
+              variant="primary"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Connecting"
+              loadingDots={5}
+            >
+              Connect to Server
+            </Button>
+            <Button 
+              variant="accent"
+              isPending={false}
+              loadingStyle="terminal"
+              loadingText="Analyzing"
+            >
+              Run Analysis
+            </Button>
+          </Flex>
+        </Flex>
+      </View>
+    </View>
+  );
+}
+
+export default TerminalLoadingExample;


### PR DESCRIPTION
Closes <!-- Github issue # here -->

Adds comprehensive documentation for the new `loadingStyle="terminal"` prop for the Button component. This includes updated `Button.mdx` with usage and examples, a detailed `TERMINAL_LOADING.md` technical reference, and a `TerminalLoadingExample.tsx` file for interactive demonstrations.

## ✅ Pull Request Checklist:

- [ ] Included link to corresponding [React Spectrum GitHub Issue](https://github.com/adobe/react-spectrum/issues).
- [ ] Added/updated unit tests and storybook for this change (for new code or code which already has tests).
- [x] Filled out test instructions.
- [x] Updated documentation (if it already exists for this component).
- [x] Looked at the Accessibility Practices for this feature - [Aria Practices](https://www.w3.org/WAI/ARIA/apg/)

## 📝 Test Instructions:

To test this pull request:
1.  Review the updated `packages/@react-spectrum/button/docs/Button.mdx` to see the new "Terminal Loading Style" section, including usage, customization, accessibility, and internationalization examples.
2.  Run the `packages/@react-spectrum/button/examples/TerminalLoadingExample.tsx` file in a development environment (e.g., Storybook) to interact with the various configurations of the terminal loading feature.
3.  Examine `packages/@react-spectrum/button/TERMINAL_LOADING.md` for detailed technical documentation, API reference, and implementation notes.

## 🧢 Your Project:

---
<a href="https://cursor.com/background-agent?bcId=bc-9a353830-dc79-4607-82fa-9e08441624d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a353830-dc79-4607-82fa-9e08441624d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

